### PR TITLE
Issue #21: Tests in CasSerializerTest fail on Windows due to line endings

### DIFF
--- a/src/test/java/org/apache/uima/json/jsoncas2/ser/CasSerializerTest.java
+++ b/src/test/java/org/apache/uima/json/jsoncas2/ser/CasSerializerTest.java
@@ -64,7 +64,7 @@ class CasSerializerTest {
     sut.setTypeSystemMode(TypeSystemMode.MINIMAL);
     sut.serialize(cas, out);
 
-    assertThat(contentOf(out, UTF_8)).isEqualTo(
+    assertThat(contentOf(out, UTF_8)).isEqualToNormalizingNewlines(
             contentOf(getClass().getResource("/CasSerializerTest/minimalTypeSystem.json"), UTF_8));
   }
 
@@ -78,7 +78,7 @@ class CasSerializerTest {
     sut.setTypeSystemMode(TypeSystemMode.FULL);
     sut.serialize(cas, out);
 
-    assertThat(contentOf(out, UTF_8)).isEqualTo(
+    assertThat(contentOf(out, UTF_8)).isEqualToNormalizingNewlines(
             contentOf(getClass().getResource("/CasSerializerTest/fullTypeSystem.json"), UTF_8));
   }
 
@@ -92,7 +92,7 @@ class CasSerializerTest {
     sut.setTypeSystemMode(TypeSystemMode.NONE);
     sut.serialize(cas, out);
 
-    assertThat(contentOf(out, UTF_8)).isEqualTo(
+    assertThat(contentOf(out, UTF_8)).isEqualToNormalizingNewlines(
             contentOf(getClass().getResource("/CasSerializerTest/noTypeSystem.json"), UTF_8));
   }
 


### PR DESCRIPTION
**What's in the PR**
- Normalize the line endings for the purpose of the test

**How to test manually**
* Run the CasSerializerTest on Windows

**Automatic testing**
* [ ] PR adds/updates unit tests

**Documentation**
* [ ] PR adds/updates documentation

**Organizational**
- [ ] PR adds/updates dependencies.
      <sub><sup>Only dependencies under [approved licenses](http://www.apache.org/legal/resolved.html#category-a) are allowed. LICENSE and NOTICE files in the respective modules where dependencies have been added as well as in the project root have been updated.</sup></sub>
